### PR TITLE
Fixed recognizing tablet devices

### DIFF
--- a/django_adaptive/loader_utils.py
+++ b/django_adaptive/loader_utils.py
@@ -17,11 +17,11 @@ def get_template_suffix():
 
     suffix = DESKTOP
 
-    if hasattr(request, 'mobile') and request.mobile:
-        suffix = MOBILE
-
-    elif hasattr(request, 'tablet') and request.tablet:
+    if hasattr(request, 'tablet') and request.tablet:
         suffix = TABLET
+
+    elif hasattr(request, 'mobile') and request.mobile:
+        suffix = MOBILE
 
     return suffix
 


### PR DESCRIPTION
django-mobi sets request.mobile = True and request.tablet = True for tablet devices and as of this adaptive recognized tabled devices as mobile.
